### PR TITLE
Fix keyboard navigation with Shift-Tab

### DIFF
--- a/Mile.Xaml/Mile.Xaml.cpp
+++ b/Mile.Xaml/Mile.Xaml.cpp
@@ -96,8 +96,7 @@ namespace
                 winrt::DesktopWindowXamlSource sender,
                 winrt::DesktopWindowXamlSourceTakeFocusRequestedEventArgs args)
             {
-                sender.Content().as<winrt::Control>().Focus(
-                    winrt::FocusState::Programmatic);
+                sender.NavigateFocus(args.Request());
             });
 
             if (!::SetPropW(


### PR DESCRIPTION
<!--
If you don't follow the following rules, your PR won't be merged and closed 
immediately.

- You are forbidden to modify any content in any files and folders starting 
  with the "Mile.Project." prefix.
--> 

Allow focus to cycle correctly with Shift-Tab (in reverse order) as well as Tab.