### PR TITLE
Hope to add IInitializeWithWindow support

### DIFF
--- a/Mile.Xaml.Managed/Interop/IInitializeWithWindow.cs
+++ b/Mile.Xaml.Managed/Interop/IInitializeWithWindow.cs
@@ -1,0 +1,23 @@
+﻿/*
+ * PROJECT:   Mouri Internal Library Essentials
+ * FILE:      IInitializeWithWindow.cs
+ * PURPOSE:   Definition for Mile.Xaml.Interop.IInitializeWithWindow
+ *
+ * LICENSE:   The MIT License
+ *
+ * MAINTAINER: MouriNaruto (Kenji.Mouri@outlook.com)
+ */
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Mile.Xaml.Interop
+{
+    [ComImport]
+    [Guid("3E68D4BD-7135-4D10-8018-9FB6D9F33FA1")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IInitializeWithWindow
+    {
+        void Initialize(IntPtr hwnd);
+    }
+}


### PR DESCRIPTION
Hope to add IInitializeWithWindow support for desktop apps.
希望为桌面应用程序添加IInitializeWithWindow支持。

CsWinRT can through WinRT. Interop. IInitializeWithWindow methods for operation, and hope to get the Xaml can also in the.net Framework provides a similar approach
CsWinRT 中可以通过 WinRT.Interop.IInitializeWithWindow 方法来进行操作，希望 Mile.Xaml 也能在 .NET Framework 中提供类似的方法

https://learn.microsoft.com/zh-cn/windows/win32/api/shobjidl_core/nn-shobjidl_core-iinitializewithwindow