### PR TITLE
.NET 8 support

### DIFF
--- a/Mile.Xaml.Managed/Interop/ICoreWindowInterop.cs
+++ b/Mile.Xaml.Managed/Interop/ICoreWindowInterop.cs
@@ -10,15 +10,22 @@
 
 using System;
 using System.Runtime.InteropServices;
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 
 namespace Mile.Xaml.Interop
 {
+#if NET8_0_OR_GREATER
+    [GeneratedComInterface]
+#else
     [ComImport]
-    [Guid("45D64A29-A63E-4CB6-B498-5781D298CB4F")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface ICoreWindowInterop
+#endif
+    [Guid("45D64A29-A63E-4CB6-B498-5781D298CB4F")]
+    public partial interface ICoreWindowInterop
     {
-        IntPtr WindowHandle { get; }
-        bool MessageHandled { set; }
+        IntPtr GetWindowHandle();
+        void SetMessageHandled([MarshalAs(UnmanagedType.I1)]bool messageHandled);
     }
 }

--- a/Mile.Xaml.Managed/Interop/ICoreWindowInterop.cs
+++ b/Mile.Xaml.Managed/Interop/ICoreWindowInterop.cs
@@ -25,7 +25,10 @@ namespace Mile.Xaml.Interop
     [Guid("45D64A29-A63E-4CB6-B498-5781D298CB4F")]
     public partial interface ICoreWindowInterop
     {
+        // Original declaration: IntPtr WindowHandle { get; }
         IntPtr GetWindowHandle();
+
+        // Original declaration: bool MessageHandled { set; }
         void SetMessageHandled([MarshalAs(UnmanagedType.I1)]bool messageHandled);
     }
 }

--- a/Mile.Xaml.Managed/Interop/IDesktopWindowXamlSourceNative2.cs
+++ b/Mile.Xaml.Managed/Interop/IDesktopWindowXamlSourceNative2.cs
@@ -27,6 +27,7 @@ namespace Mile.Xaml.Interop
     {
         void AttachToWindow(IntPtr parentWnd);
 
+        // Original declaration: IntPtr WindowHandle { get; }
         IntPtr GetWindowHandle();
 
         [return:MarshalAs(UnmanagedType.I1)]

--- a/Mile.Xaml.Managed/Interop/IDesktopWindowXamlSourceNative2.cs
+++ b/Mile.Xaml.Managed/Interop/IDesktopWindowXamlSourceNative2.cs
@@ -10,18 +10,26 @@
 
 using System;
 using System.Runtime.InteropServices;
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 
 namespace Mile.Xaml.Interop
 {
+#if NET8_0_OR_GREATER
+    [GeneratedComInterface]
+#else
     [ComImport]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+#endif
     [Guid("e3dcd8c7-3057-4692-99c3-7b7720afda31")]
-    public interface IDesktopWindowXamlSourceNative2
+    public partial interface IDesktopWindowXamlSourceNative2
     {
         void AttachToWindow(IntPtr parentWnd);
 
-        IntPtr WindowHandle { get; }
+        IntPtr GetWindowHandle();
 
+        [return:MarshalAs(UnmanagedType.I1)]
         bool PreTranslateMessage(ref System.Windows.Forms.Message message);
     }
 }

--- a/Mile.Xaml.Managed/Interop/IInitializeWithWindow.cs
+++ b/Mile.Xaml.Managed/Interop/IInitializeWithWindow.cs
@@ -10,13 +10,20 @@
 
 using System;
 using System.Runtime.InteropServices;
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 
 namespace Mile.Xaml.Interop
 {
+#if NET8_0_OR_GREATER
+    [GeneratedComInterface]
+#else
     [ComImport]
-    [Guid("3E68D4BD-7135-4D10-8018-9FB6D9F33FA1")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IInitializeWithWindow
+#endif
+    [Guid("3E68D4BD-7135-4D10-8018-9FB6D9F33FA1")]
+    public partial interface IInitializeWithWindow
     {
         void Initialize(IntPtr hwnd);
     }

--- a/Mile.Xaml.Managed/Interop/IWindowPrivate.cs
+++ b/Mile.Xaml.Managed/Interop/IWindowPrivate.cs
@@ -25,9 +25,12 @@ namespace Mile.Xaml.Interop
     [Guid("06636C29-5A17-458D-8EA2-2422D997A922")]
     public partial interface IWindowPrivate
     {
+        // IInspectable methods
         void GetIids(out int iidCount, out IntPtr iids);
         void GetRuntimeClassName(out IntPtr className);
         void GetTrustLevel(out int trustLevel);
+
+        // Original declaration: bool TransparentBackground { get; set; }
         [return: MarshalAs(UnmanagedType.I1)] bool GetTransparentBackground();
         void SetTransparentBackground([MarshalAs(UnmanagedType.I1)] bool transparentBackground);
     }

--- a/Mile.Xaml.Managed/Interop/IWindowPrivate.cs
+++ b/Mile.Xaml.Managed/Interop/IWindowPrivate.cs
@@ -10,14 +10,25 @@
 
 using System;
 using System.Runtime.InteropServices;
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 
 namespace Mile.Xaml.Interop
 {
+#if NET8_0_OR_GREATER
+    [GeneratedComInterface]
+#else
     [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+#endif
     [Guid("06636C29-5A17-458D-8EA2-2422D997A922")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIInspectable)]
-    public interface IWindowPrivate
+    public partial interface IWindowPrivate
     {
-        bool TransparentBackground { get; set; }
+        void GetIids(out int iidCount, out IntPtr iids);
+        void GetRuntimeClassName(out IntPtr className);
+        void GetTrustLevel(out int trustLevel);
+        [return: MarshalAs(UnmanagedType.I1)] bool GetTransparentBackground();
+        void SetTransparentBackground([MarshalAs(UnmanagedType.I1)] bool transparentBackground);
     }
 }

--- a/Mile.Xaml.Managed/Interop/InteropExtensions.cs
+++ b/Mile.Xaml.Managed/Interop/InteropExtensions.cs
@@ -21,6 +21,10 @@ namespace Mile.Xaml.Interop
         public static IDesktopWindowXamlSourceNative2 GetInterop(
             this DesktopWindowXamlSource BaseObject)
         {
+#if NET8_0_OR_GREATER
+            IDesktopWindowXamlSourceNative2 InteropObject = (IDesktopWindowXamlSourceNative2)(object)BaseObject;
+            return InteropObject;
+#else
             IntPtr BaseObjectIntPtr = Marshal.GetIUnknownForObject(BaseObject);
             try
             {
@@ -33,11 +37,16 @@ namespace Mile.Xaml.Interop
             {
                 Marshal.Release(BaseObjectIntPtr);
             }
+#endif
         }
 
         public static ICoreWindowInterop GetInterop(
             this CoreWindow BaseObject)
         {
+#if NET8_0_OR_GREATER
+            ICoreWindowInterop InteropObject = (ICoreWindowInterop)(object)BaseObject;
+            return InteropObject;
+#else
             IntPtr BaseObjectIntPtr = Marshal.GetIUnknownForObject(BaseObject);
             try
             {
@@ -50,10 +59,15 @@ namespace Mile.Xaml.Interop
             {
                 Marshal.Release(BaseObjectIntPtr);
             }
+#endif
         }
 
         public static IWindowPrivate GetInterop(this Window BaseObject)
         {
+#if NET8_0_OR_GREATER
+            IWindowPrivate InteropObject = (IWindowPrivate)(object)BaseObject;
+            return InteropObject;
+#else
             IntPtr BaseObjectIntPtr = Marshal.GetIUnknownForObject(BaseObject);
             try
             {
@@ -66,6 +80,7 @@ namespace Mile.Xaml.Interop
             {
                 Marshal.Release(BaseObjectIntPtr);
             }
+#endif
         }
     }
 }

--- a/Mile.Xaml.Managed/Interop/UnsafeNativeMethods.cs
+++ b/Mile.Xaml.Managed/Interop/UnsafeNativeMethods.cs
@@ -19,8 +19,13 @@ namespace Mile.Xaml.Interop
         ///  SecurityCritical: This code happens to return a critical resource and causes unmanaged code elevation
         /// </SecurityNote>
         /// <returns>handle</returns>
+#if NET8_0_OR_GREATER
+        [LibraryImport(ExternDll.User32, SetLastError = true, EntryPoint = "SetFocus")]
+        internal static partial IntPtr IntSetFocus(IntPtr hWnd);
+#else
         [DllImport(ExternDll.User32, EntryPoint = "SetFocus", ExactSpelling = true, CharSet = CharSet.Auto, SetLastError = true)]
         internal static extern IntPtr IntSetFocus(IntPtr hWnd);
+#endif
 
         /// <summary>
         /// Changes an attribute of the specified window. The function also sets the 32-bit (long) value at the specified offset into the extra window memory.
@@ -29,7 +34,12 @@ namespace Mile.Xaml.Interop
         /// <param name="nIndex">Zero-based offset</param>
         /// <param name="dwNewLong">The replacement value</param>
         /// <returns>A positive integer indicates success; zero indicates failure</returns>
+#if NET8_0_OR_GREATER
+        [LibraryImport(ExternDll.User32, SetLastError = true, EntryPoint = "SetWindowLongW", StringMarshalling = StringMarshalling.Utf16)]
+        internal static partial int SetWindowLong(IntPtr hWnd, int nIndex, uint dwNewLong);
+#else
         [DllImport(ExternDll.User32, SetLastError = true)]
         internal static extern int SetWindowLong(IntPtr hWnd, int nIndex, uint dwNewLong);
+#endif
     }
 }

--- a/Mile.Xaml.Managed/Mile.Xaml.Managed.csproj
+++ b/Mile.Xaml.Managed/Mile.Xaml.Managed.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;net8.0-windows</TargetFrameworks>
     <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <LangVersion>latest</LangVersion>
@@ -11,9 +11,21 @@
     <Copyright>© Project Mile. All rights reserved.</Copyright>
     <Version>2.2.$([System.DateTime]::Today.Subtract($([System.DateTime]::Parse('2021-09-12'))).TotalDays).0</Version>
     <UseWindowsForms>true</UseWindowsForms>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
+  <PropertyGroup Condition="$(TargetFramework) == 'net8.0-windows'">
+    <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
+    <IsAotCompatible>true</IsAotCompatible>
+    <WindowsSdkPackageVersion>$([System.Version]::Parse('$(TargetPlatformMinVersion)').ToString(3)).39</WindowsSdkPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net8.0-windows'">
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.DisableRuntimeMarshalling" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net48'">
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="$([System.Version]::Parse('$(TargetPlatformVersion)').ToString(3)).*" />
   </ItemGroup>
 

--- a/Mile.Xaml.Managed/WindowsXamlHostBase.cs
+++ b/Mile.Xaml.Managed/WindowsXamlHostBase.cs
@@ -226,7 +226,7 @@ namespace Mile.Xaml
                 // Attach window to DesktopWindowXamSource as a render target
                 var XamlSourceNative = _xamlSource.GetInterop();
                 XamlSourceNative.AttachToWindow(Handle);
-                _xamlIslandWindowHandle = XamlSourceNative.WindowHandle;
+                _xamlIslandWindowHandle = XamlSourceNative.GetWindowHandle();
 
                 // Set window style required by container control to support Focus and background refresh
                 if (Interop.UnsafeNativeMethods.SetWindowLong(Handle, Interop.NativeDefines.GWL_EXSTYLE, Interop.NativeDefines.WS_EX_CONTROLPARENT | Interop.NativeDefines.WS_EX_LAYERED) == 0)

--- a/Mile.Xaml.Managed/XamlApplicationExtensions.cs
+++ b/Mile.Xaml.Managed/XamlApplicationExtensions.cs
@@ -16,12 +16,22 @@ using Windows.UI.Xaml.Hosting;
 
 namespace Mile.Xaml
 {
-    public static class XamlApplicationExtensions
+    public static partial class XamlApplicationExtensions
     {
         private const uint PM_NOREMOVE = 0x0000;
         private const uint PM_REMOVE = 0x0001;
         private const uint PM_NOYIELD = 0x0002;
 
+#if NET8_0_OR_GREATER
+        [LibraryImport("user32.dll", EntryPoint = "PeekMessageW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool PeekMessage(
+            out System.Windows.Forms.Message lpMsg,
+            IntPtr hWnd,
+            uint wMsgFilterMin,
+            uint wMsgFilterMax,
+            uint wRemoveMsg);
+#else
         [DllImport("user32.dll", CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool PeekMessage(
@@ -30,10 +40,18 @@ namespace Mile.Xaml
             uint wMsgFilterMin,
             uint wMsgFilterMax,
             uint wRemoveMsg);
+#endif
 
+#if NET8_0_OR_GREATER
+        [LibraryImport("user32.dll", EntryPoint = "DispatchMessageW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        private static partial IntPtr DispatchMessage(
+            ref System.Windows.Forms.Message lpMsg);
+#else
         [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         private static extern IntPtr DispatchMessage(
             ref System.Windows.Forms.Message lpMsg);
+#endif
+
 
         [ThreadStatic]
         private static WindowsXamlManager XamlManager = null;
@@ -84,14 +102,14 @@ namespace Mile.Xaml
         public static bool GetTransparentBackgroundAttribute(
             this Application BaseObject)
         {
-            return Window.Current.GetInterop().TransparentBackground;
+            return Window.Current.GetInterop().GetTransparentBackground();
         }
 
         public static void SetTransparentBackgroundAttribute(
             this Application BaseObject,
             bool AttributeValue)
         {
-            Window.Current.GetInterop().TransparentBackground = AttributeValue;
+            Window.Current.GetInterop().SetTransparentBackground(AttributeValue);
         }
     }
 }

--- a/Mile.Xaml.sln
+++ b/Mile.Xaml.sln
@@ -34,6 +34,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "net48", "net48", "{14C8B3F2
 		Mile.Xaml\NuGet\net48\Mile.Xaml.targets = Mile.Xaml\NuGet\net48\Mile.Xaml.targets
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "net8.0", "net8.0", "{2B753308-E55A-491B-B2FE-3CC4422864D6}"
+	ProjectSection(SolutionItems) = preProject		
+		Mile.Xaml\NuGet\net8.0\Mile.Xaml.props = Mile.Xaml\NuGet\net8.0\Mile.Xaml.props
+		Mile.Xaml\NuGet\net8.0\Mile.Xaml.targets = Mile.Xaml\NuGet\net8.0\Mile.Xaml.targets
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -80,6 +86,7 @@ Global
 		{EB76F0B3-3CE0-4517-8BF2-367C53D745AA} = {931D228C-8E9D-47E5-A535-3F356CA96E78}
 		{1A7C0865-004B-454E-9AB7-35D593AFAF25} = {EB76F0B3-3CE0-4517-8BF2-367C53D745AA}
 		{14C8B3F2-E47B-49F5-9EA3-EB207CBECFCC} = {EB76F0B3-3CE0-4517-8BF2-367C53D745AA}
+		{2B753308-E55A-491B-B2FE-3CC4422864D6} = {EB76F0B3-3CE0-4517-8BF2-367C53D745AA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7988428E-156C-4D84-8DEE-989B06041193}

--- a/Mile.Xaml/Mile.Xaml.nuspec
+++ b/Mile.Xaml/Mile.Xaml.nuspec
@@ -25,6 +25,9 @@
       <group targetFramework=".NETFramework4.8">
         <dependency id="Microsoft.Windows.SDK.Contracts" version="10.0.19041.1" />
       </group>
+      <group targetFramework="net8.0-windows10.0.19041.0">
+        <dependency id="DisposableMemory.ModernNetUAP.XamlCompiler" version="0.2.0" />
+      </group>
     </dependencies>
     <repository type="git" url="https://github.com/ProjectMile/Mile.Xaml.git" />
   </metadata>
@@ -38,6 +41,8 @@
     <file src="NuGet\net48\Mile.Xaml.AfterImport.targets" target="build\net48" />
     <file src="NuGet\net48\Mile.Xaml.props" target="build\net48" />
     <file src="NuGet\net48\Mile.Xaml.targets" target="build\net48" />
+    <file src="NuGet\net8.0\Mile.Xaml.targets" target="build\net8.0-windows10.0.19041.0" />
+    <file src="NuGet\net8.0\Mile.Xaml.props" target="build\net8.0-windows10.0.19041.0" />
     <file src="NuGet\MrtCore.PriGen.targets" target="build" />
 
     <file src="..\Output\Binaries\Release\x64\Mile.Xaml.Styles.SunValley.xbf" target="Redist\Styles" />
@@ -48,6 +53,9 @@
 
     <file src="..\Output\Binaries\Release\AnyCPU\net48\Mile.Xaml.Managed.dll" target="lib\net48" />
     <file src="..\Output\Binaries\Release\AnyCPU\net48\Mile.Xaml.Managed.pdb" target="lib\net48" />
+
+    <file src="..\Output\Binaries\Release\AnyCPU\net8.0-windows\Mile.Xaml.Managed.dll" target="lib\net8.0-windows10.0.19041.0" />
+    <file src="..\Output\Binaries\Release\AnyCPU\net8.0-windows\Mile.Xaml.Managed.pdb" target="lib\net8.0-windows10.0.19041.0" />
 
     <file src="..\ReadMe.md" target="." />
     <file src="..\License.md" target="." />

--- a/Mile.Xaml/NuGet/net8.0/Mile.Xaml.props
+++ b/Mile.Xaml/NuGet/net8.0/Mile.Xaml.props
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+   PROJECT:   Mouri Internal Library Essentials
+   FILE:      Mile.Xaml.props
+   PURPOSE:   MSBuild props file for Mile.Xaml .NET 8 target
+
+   LICENSE:   The MIT License
+
+   DEVELOPER: driver1998 (github.com/driver1998)
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<!-- Remove UWP Default Main Method -->
+		<DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+	</PropertyGroup>
+</Project>

--- a/Mile.Xaml/NuGet/net8.0/Mile.Xaml.targets
+++ b/Mile.Xaml/NuGet/net8.0/Mile.Xaml.targets
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+   PROJECT:   Mouri Internal Library Essentials
+   FILE:      Mile.Xaml.targets
+   PURPOSE:   MSBuild targets file for Mile.Xaml .NET 8 target
+
+   LICENSE:   The MIT License
+
+   MAINTAINER: MouriNaruto (Kenji.Mouri@outlook.com)
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition="'$(MileXamlNoSunValleyXamlStyle)' != 'true'">
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\Redist\Styles\Mile.Xaml.Styles.SunValley.xbf" />
+  </ItemGroup>
+
+  <!-- Must use .NET SDK and install Windows SDK -->
+  <Target Name="CheckNetSdkEnvironment" BeforeTargets="BeforeBuild">
+    <Error Text="Must use .NET SDK." Condition="'$(UsingMicrosoftNETSdk)' != 'true'" />
+    <Error Text="Can't find Windows.UI.Xaml Compiler, please install Microsoft.Windows.SDK.CPP in NuGet Package Manager." Condition="!Exists($(WindowsKitsXamlCompilerTargetsPath))" />
+  </Target>
+</Project>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -58,5 +58,6 @@ in your project configuration file.
 Note: This list sort in alphabetical order.
 
 - AndromedaMelody, https://github.com/AndromedaMelody
+- driver1998, https://github.com/driver1998
 - Kenji Mouri, https://github.com/MouriNaruto
 - Yifei Gao (高怡飞), https://github.com/Gaoyifei1011


### PR DESCRIPTION
This is a port of Mile.Xaml to .NET 8, currently the WinForms Mile.Xaml.Managed implementation only.

XAML compiler enablement depends on my [ModernUAP.XamlCompiler nuget](https://www.nuget.org/packages/DisposableMemory.ModernNetUAP.XamlCompiler). No runtime dependencies from there though, only build time dependencies. I can also move the bits from that nuget to Mile.Xaml itself if you want (the basis are copied from here anyway).

AOT works fine (WinForms AOT issues not withstanding).

![image](https://github.com/user-attachments/assets/f7a3f5b5-db01-401e-8f56-46ada08da175)
