### PR TITLE
Official Windows.UI.Xaml Modern .NET support

### DIFF
--- a/Mile.Xaml.Managed/Mile.Xaml.Managed.csproj
+++ b/Mile.Xaml.Managed/Mile.Xaml.Managed.csproj
@@ -18,7 +18,9 @@
   <PropertyGroup Condition="$(TargetFramework) == 'net8.0-windows'">
     <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
     <IsAotCompatible>true</IsAotCompatible>
-    <WindowsSdkPackageVersion>$([System.Version]::Parse('$(TargetPlatformMinVersion)').ToString(3)).39</WindowsSdkPackageVersion>
+    <UseUwp>true</UseUwp>
+    <UseUwpTools>false</UseUwpTools>
+    <WindowsSdkPackageVersion>$([System.Version]::Parse('$(TargetPlatformMinVersion)').ToString(3)).57</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0-windows'">

--- a/Mile.Xaml/Mile.Xaml.nuspec
+++ b/Mile.Xaml/Mile.Xaml.nuspec
@@ -25,9 +25,7 @@
       <group targetFramework=".NETFramework4.8">
         <dependency id="Microsoft.Windows.SDK.Contracts" version="10.0.19041.1" />
       </group>
-      <group targetFramework="net8.0-windows10.0.19041.0">
-        <dependency id="DisposableMemory.ModernNetUAP.XamlCompiler" version="0.2.0" />
-      </group>
+      <group targetFramework="net8.0-windows10.0.19041.0"/>
     </dependencies>
     <repository type="git" url="https://github.com/ProjectMile/Mile.Xaml.git" />
   </metadata>

--- a/Mile.Xaml/NuGet/net48/Mile.Xaml.props
+++ b/Mile.Xaml/NuGet/net48/Mile.Xaml.props
@@ -31,4 +31,9 @@
     <!-- Set the XAML runtime setting to UAP to workaround -->
     <DefaultXamlRuntime>UAP</DefaultXamlRuntime>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Enable Windows.UI.Xaml XAML templates for .NET Framework -->
+    <ProjectCapability Include="Uwp" />
+  </ItemGroup>
 </Project>

--- a/Mile.Xaml/NuGet/net8.0/Mile.Xaml.props
+++ b/Mile.Xaml/NuGet/net8.0/Mile.Xaml.props
@@ -3,14 +3,36 @@
    PROJECT:   Mouri Internal Library Essentials
    FILE:      Mile.Xaml.props
    PURPOSE:   MSBuild props file for Mile.Xaml .NET 8 target
+              Note: .NET 9 SDK or higher is required
 
    LICENSE:   The MIT License
 
    DEVELOPER: driver1998 (github.com/driver1998)
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<PropertyGroup>
-		<!-- Remove UWP Default Main Method -->
-		<DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
-	</PropertyGroup>
+   <PropertyGroup>
+      <!-- Remove UWP Default Main Method -->
+      <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+      <!-- Disable Microsoft.NET.Sdk.WindowsDesktop Toolchain -->
+      <ImportWindowsDesktopTargets>false</ImportWindowsDesktopTargets>
+      <!-- Disable WPF XAML Compiler Toolchain -->
+      <ImportFrameworkWinFXTargets>false</ImportFrameworkWinFXTargets>
+      <!-- Allow importing Assemblies by UseWindowsForms and UseWPF -->
+      <_EnableWindowsDesktopNetCoreFrameworkReferences>true</_EnableWindowsDesktopNetCoreFrameworkReferences>
+      <!-- Use C#/WinRT Windows.UI.Xaml Projection -->
+      <UseUwp>true</UseUwp>
+      <!-- Enable Windows.UI.Xaml XAML Compiler -->
+      <UseUwpTools>true</UseUwpTools>
+      <!-- Remove VCLibs package reference -->
+      <AddMicrosoftVCLibsSDKReference>false</AddMicrosoftVCLibsSDKReference>
+      <!-- Remove debug UCRT package reference -->
+      <AddMicrosoftUniversalCRTDebugSDKReference>false</AddMicrosoftUniversalCRTDebugSDKReference>
+      <!-- Some properties and targets must be import after CommonTargets -->
+      <CustomAfterMicrosoftCommonTargets>
+         $(CustomAfterMicrosoftCSharpTargets);
+         $(MSBuildThisFileDirectory)..\MrtCore.PriGen.targets;
+      </CustomAfterMicrosoftCommonTargets>
+      <!-- Set the XAML runtime setting to UAP to workaround -->
+      <DefaultXamlRuntime>UAP</DefaultXamlRuntime>
+   </PropertyGroup>
 </Project>

--- a/Mile.Xaml/NuGet/net8.0/Mile.Xaml.targets
+++ b/Mile.Xaml/NuGet/net8.0/Mile.Xaml.targets
@@ -18,4 +18,19 @@
     <Error Text="Must use .NET SDK." Condition="'$(UsingMicrosoftNETSdk)' != 'true'" />
     <Error Text="Can't find Windows.UI.Xaml Compiler, please install Microsoft.Windows.SDK.CPP in NuGet Package Manager." Condition="!Exists($(WindowsKitsXamlCompilerTargetsPath))" />
   </Target>
+  
+  <!-- .NET 9 does not resolve WPF references when UseWindowsForms=true but UseWPF=false,
+       having WindowsFormsIntegration.dll in this case will result in build error -->
+  <Target Name="RemoveWindowsFormsIntegrationOnNet9"
+          Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 9 and '$(UseWindowsForms)' == 'true' and '$(UseWPF)' != 'true'"
+          BeforeTargets="MarkupCompilePass1">
+    <ItemGroup>
+      <ReferencePath Remove="@(ReferencePath)"  Condition="'%(Filename)' == 'WindowsFormsIntegration'" />
+    </ItemGroup>
+  </Target>
+
+  <!-- A dummy target to override the one in Microsoft.Windows.UI.Xaml.ModernNET.CSharp.targets,
+       allowing UseUwp and UseWindowsForms to coexist -->
+  <Target Name="CheckForInvalidUseUwpToolsMixedConfigurations"/>
+
 </Project>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -42,6 +42,32 @@ XAML controls (Mile.Xaml.Styles.SunValley.xbf) to your project's output folder,
 please set `<MileXamlNoSunValleyXamlStyle>true</MileXamlNoSunValleyXamlStyle>`
 in your project configuration file.
 
+## Notes About Modern .NET Support
+
+Modern .NET support is based on the 
+[official UWP Support in .NET 9 SDK](https://devblogs.microsoft.com/ifdef-windows/preview-uwp-support-for-dotnet-9-native-aot/), 
+which requires the following components:
+
+- .NET 9.0 SDK
+- Visual Studio 2022 v17.12
+- Windows 11 SDK 26100.1882
+
+Warning: the MSI version of Windows 11 SDK (and the 26100 SDK provided in VS) 
+is still at 26100.1742, which does not support the C#/WinRT mode of UWP XAML compiler. 
+
+If you installed it, you may see similar errors during build: 
+
+```
+error MSB4064: The "UsingCsWinRT" parameter is not supported by the "CompileXaml" task loaded from assembly: Microsoft.Windows.UI.Xaml.Build.Tasks, Version=0.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35 from the path: C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\XamlCompiler\Microsoft.Windows.UI.Xaml.Build.Tasks.dll. Verify that the parameter exists on the task, the <UsingTask> points to the correct assembly, and it is a settable public instance property.
+```
+
+Installing a newer NuGet version of SDK on your project **may not work**, 
+as VS will still prefer the globally installed version.
+
+To workaround this, you need to manually upgrade the XAML compiler in Windows SDK. 
+[Download the standalone XAML compiler from Microsoft](https://aka.ms/preview-uwp-support-for-dotnet9-windows-sdk) 
+and follow the instructions in the README file.
+
 ## System Requirements
 
 - Supported OS: Windows 10 Version 2004 (Build 19041) or later


### PR DESCRIPTION
Requirements:

- .NET 9 SDK or higher (can target .NET 8)
- Windows 11 SDK 26100.1882 or higher
- Visual Studio 2022 v17.12

Notes:

- Windows 11 SDK MSI Installer (And the 26100 SDK provided in VS) is still at 26100.1742, which does not support the C#/WinRT mode of WUX XAML compiler. Install the updated Microsoft.Windows.SDK.CPP nuget package, or manually upgrade `Microsoft.Windows.UI.Xaml.Build.Tasks.dll` and `Microsoft.Windows.UI.Xaml.Common.targets` to newer versions.
- The old method with `ModernNetUAP.XamlCompiler` is removed.

![image](https://github.com/user-attachments/assets/bd2cd9fb-71e1-4e14-b62f-356c70c70d42)

